### PR TITLE
feat(screen): add MIRROIR_OMIT_SCREENSHOT env var to suppress screenshot in describe_screen

### DIFF
--- a/Sources/HelperLib/EnvConfigFeatures.swift
+++ b/Sources/HelperLib/EnvConfigFeatures.swift
@@ -248,6 +248,12 @@ extension EnvConfig {
         readInt("ocrMinImageWidth", default: TimingConstants.ocrMinImageWidth)
     }
 
+    /// When true, describe_screen omits the screenshot image from its response.
+    /// Use this to prevent context overflow in long automation sessions.
+    public static var describeScreenOmitScreenshot: Bool {
+        readBool("describeScreenOmitScreenshot", envVar: "MIRROIR_OMIT_SCREENSHOT", default: false)
+    }
+
     // MARK: - YOLO Element Detection
 
     /// OCR backend selection: "auto", "vision", "yolo", or "both".

--- a/Sources/mirroir-mcp/ScreenTools.swift
+++ b/Sources/mirroir-mcp/ScreenTools.swift
@@ -152,13 +152,10 @@ extension MirroirMCP {
                 lines.append("_meta: ocr_time_ms=\(result.ocrTimeMs) recognition_level=\(EnvConfig.ocrRecognitionLevel) element_count=\(result.elements.count)")
                 let description = lines.joined(separator: "\n")
 
-                return MCPToolResult(
-                    content: [
-                        .text(description),
-                        .image(result.screenshotBase64, mimeType: "image/png"),
-                    ],
-                    isError: false
-                )
+                let content: [MCPContent] = EnvConfig.describeScreenOmitScreenshot
+                    ? [.text(description)]
+                    : [.text(description), .image(result.screenshotBase64, mimeType: "image/png")]
+                return MCPToolResult(content: content, isError: false)
             }
         ))
 


### PR DESCRIPTION
## Summary

- Adds `describeScreenOmitScreenshot` config flag (env var: `MIRROIR_OMIT_SCREENSHOT`) to `EnvConfig` in `EnvConfigFeatures.swift`
- When the env var is set to a truthy value, `describe_screen` returns text-only content (no base64-encoded PNG image)
- Useful for preventing context window overflow in long automation sessions where the screenshot is not needed

## Motivation

In extended automation runs, each `describe_screen` call embeds a full PNG screenshot as base64 in the response, which can rapidly exhaust the LLM's context window. This change provides an opt-in escape hatch to skip the image when only the text description is needed.

## Changes

- `Sources/HelperLib/EnvConfigFeatures.swift`: adds `describeScreenOmitScreenshot` computed property backed by `MIRROIR_OMIT_SCREENSHOT` env var (default: `false`)
- `Sources/mirroir-mcp/ScreenTools.swift`: conditionally omits the `.image(...)` content item based on the flag

## Usage

```sh
# Omit screenshot from describe_screen responses
export MIRROIR_OMIT_SCREENSHOT=true
```

Or in MCP server config:

```json
{
  "env": {
    "MIRROIR_OMIT_SCREENSHOT": "true"
  }
}
```

## Test plan

- [ ] Build succeeds (`swift build`)
- [ ] With `MIRROIR_OMIT_SCREENSHOT` unset (default): `describe_screen` response includes both text and image content
- [ ] With `MIRROIR_OMIT_SCREENSHOT=true`: `describe_screen` response includes only text content, no image
- [ ] Existing behavior for all other tools is unaffected