### PR TITLE
feat(ocr): add configurable recognition languages via MIRROIR_OCR_LANGUAGES

### DIFF
--- a/Sources/HelperLib/EnvConfig.swift
+++ b/Sources/HelperLib/EnvConfig.swift
@@ -295,4 +295,16 @@ public enum EnvConfig {
         if let str = env[envVarName(key)], let parsed = Double(str) { return parsed }
         return fallback
     }
+
+    /// Reads a string array from settings.json (JSON array) or an env var
+    /// (comma-separated, e.g. "ja-JP,en-US"). Returns `fallback` when absent.
+    static func readStringArray(_ key: String, envVar: String? = nil,
+                                default fallback: [String]) -> [String] {
+        if let arr = settings[key] as? [String], !arr.isEmpty { return arr }
+        let varName = envVar ?? envVarName(key)
+        if let str = env[varName], !str.isEmpty {
+            return str.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        }
+        return fallback
+    }
 }

--- a/Sources/HelperLib/EnvConfigFeatures.swift
+++ b/Sources/HelperLib/EnvConfigFeatures.swift
@@ -248,6 +248,26 @@ extension EnvConfig {
         readInt("ocrMinImageWidth", default: TimingConstants.ocrMinImageWidth)
     }
 
+    /// BCP-47 language codes passed to `VNRecognizeTextRequest.recognitionLanguages`.
+    ///
+    /// When unset, Apple Vision defaults to English (`["en-US"]`). Override this
+    /// to recognise additional scripts — e.g. `["ja-JP", "en-US"]` for Japanese UI,
+    /// `["zh-Hans", "en-US"]` for Simplified Chinese, or any combination of
+    /// [Vision-supported languages](https://developer.apple.com/documentation/vision/vnrecognizetextrequest/recognitionlanguages-swift.property).
+    ///
+    /// Configure via `settings.json`:
+    /// ```json
+    /// { "ocrLanguages": ["ja-JP", "en-US"] }
+    /// ```
+    /// Or via the `MIRROIR_OCR_LANGUAGES` environment variable (comma-separated):
+    /// ```
+    /// MIRROIR_OCR_LANGUAGES=ja-JP,en-US
+    /// ```
+    public static var ocrLanguages: [String] {
+        readStringArray("ocrLanguages", envVar: "MIRROIR_OCR_LANGUAGES",
+                        default: ["en-US"])
+    }
+
     // MARK: - YOLO Element Detection
 
     /// OCR backend selection: "auto", "vision", "yolo", or "both".

--- a/Sources/mirroir-mcp/AppleVisionTextRecognizer.swift
+++ b/Sources/mirroir-mcp/AppleVisionTextRecognizer.swift
@@ -22,6 +22,7 @@ struct AppleVisionTextRecognizer: Sendable {
         let request = VNRecognizeTextRequest()
         request.recognitionLevel = EnvConfig.ocrRecognitionLevel == "fast" ? .fast : .accurate
         request.usesLanguageCorrection = EnvConfig.ocrLanguageCorrection
+        request.recognitionLanguages = EnvConfig.ocrLanguages
 
         let handler = VNImageRequestHandler(cgImage: image, options: [:])
         do {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ Every setting has a corresponding environment variable (e.g. `MIRROIR_SCREEN_DES
 | `ocrBackend` | `"auto"` | OCR backend: `"auto"`, `"vision"` (text only), `"yolo"` (icons only), or `"both"` |
 | `ocrRecognitionLevel` | `"accurate"` | Apple Vision OCR quality: `"accurate"` or `"fast"` |
 | `ocrLanguageCorrection` | `true` | Enable language correction during OCR text recognition |
+| `ocrLanguages` | `["en-US"]` | BCP-47 language codes for `VNRecognizeTextRequest.recognitionLanguages`. Add languages to recognise non-Latin scripts (e.g. `["ja-JP","en-US"]`). Also configurable via `MIRROIR_OCR_LANGUAGES` env var (comma-separated) |
 | `yoloModelURL` | `""` | URL to download a YOLO `.mlmodel` on first use |
 | `yoloModelPath` | `""` | Local path to a pre-compiled `.mlmodelc` directory (overrides download) |
 | `yoloConfidenceThreshold` | `0.3` | Minimum confidence for YOLO element detections (0.0–1.0) |


### PR DESCRIPTION
## Problem

`VNRecognizeTextRequest.recognitionLanguages` was not set, so Apple Vision defaulted to English-only OCR. UI text in non-Latin scripts is misread as garbled ASCII:

- Japanese `メモ` → `XE`
- Japanese `閉じる` → `HJ03`
- Chinese, Korean, Arabic, Cyrillic, etc. similarly affected

This makes `describe_screen` unreliable for any non-English UI.

## Solution

Add an `ocrLanguages` setting (and `MIRROIR_OCR_LANGUAGES` env var) that passes a BCP-47 language list to `VNRecognizeTextRequest.recognitionLanguages`. The default is `["en-US"]`, preserving existing behaviour for users who do not configure it.

## Changes

- **`EnvConfig.swift`** — add `readStringArray` helper: reads a JSON array from `settings.json` or a comma-separated env var. Reusable for any future array-typed settings.
- **`EnvConfigFeatures.swift`** — add `ocrLanguages: [String]` property in the OCR Configuration section.
- **`AppleVisionTextRecognizer.swift`** — pass `ocrLanguages` to `request.recognitionLanguages`.
- **`docs/configuration.md`** — document the new setting and env var.

## Configuration

**settings.json:**
```json
{
  "ocrLanguages": ["ja-JP", "en-US"]
}
```

**Environment variable (comma-separated):**
```
MIRROIR_OCR_LANGUAGES=ja-JP,en-US
```

**Supported languages:** any BCP-47 code accepted by Apple Vision — see [VNRecognizeTextRequest.recognitionLanguages](https://developer.apple.com/documentation/vision/vnrecognizetextrequest/recognitionlanguages-swift.property).

## Behaviour

| Scenario | `recognitionLanguages` value |
|---|---|
| No config (default) | `["en-US"]` — same as before |
| `settings.json` key set | uses JSON array value |
| `MIRROIR_OCR_LANGUAGES` env set | uses comma-separated values |
| Both set | `settings.json` wins |